### PR TITLE
correct unzip command in terraform update bash script

### DIFF
--- a/update-terraform.sh
+++ b/update-terraform.sh
@@ -4,7 +4,7 @@
 # only need this as long as Google Cloud Console is behind. 
 
 wget https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_linux_amd64.zip
-unzip https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_linux_amd64.zip
+unzip terraform_0.13.2_linux_amd64.zip
 mkdir -p ~/bin
 mv terraform ~/bin
 rm terraform.tfs*


### PR DESCRIPTION
The unzip command in the terraform upgrade script is referencing the wget URL instead of the downloaded package.